### PR TITLE
Add function to recolor icon, fix layout issue, add layouts and its icons from bling

### DIFF
--- a/awesome/main/layouts.lua
+++ b/awesome/main/layouts.lua
@@ -1,5 +1,6 @@
 -- Standard awesome library
 local awful = require("awful")
+local bling = require("bling")
 
 local _M = {}
 
@@ -7,7 +8,7 @@ local _M = {}
 
 function _M.get()
   -- Table of layouts to cover with awful.layout.inc, order matters.
-  local layouts = {
+  awful.layout.layouts = {
     awful.layout.suit.tile,            -- 2:
     awful.layout.suit.floating,        -- 1:
     awful.layout.suit.tile.left,       -- 3:
@@ -24,11 +25,18 @@ function _M.get()
     awful.layout.suit.max.fullscreen,  -- 11:
     awful.layout.suit.magnifier,       -- 12:
 
-    awful.layout.suit.corner.nw        -- 13:
+    awful.layout.suit.corner.nw,        -- 13:
     --  awful.layout.suit.corner.ne,
     --  awful.layout.suit.corner.sw,
     --  awful.layout.suit.corner.se,
+    -- bling.layout.centered,
+    -- bling.layout.deck,
+    -- bling.layout.equalarea,
+    -- bling.layout.horizontal,
+    -- bling.layout.mstab,
+    -- bling.layout.vertical,
   }
+  local layouts = awful.layout.layouts
 
   return layouts
 end

--- a/awesome/popups/screen_record/screenshot/main.lua
+++ b/awesome/popups/screen_record/screenshot/main.lua
@@ -361,7 +361,7 @@ open_image:connect_signal(
 fullscreen:connect_signal("button::release", function(_, _, _, button)
 	if button == 1 then
 		ss_tool.visible = false
-		awful.spawn.easy_async_with_shell('sleep 0.3 && scrot ~/Pictures/' .. ss_index .. '.png',
+		awful.spawn.easy_async_with_shell('sleep 0.3 && maim ~/Pictures/' .. ss_index .. '.png',
 			function()
 				naughty.notify
 				(
@@ -383,7 +383,7 @@ end)
 timer_button:connect_signal("button::release", function(_, _, _, button)
 	if button == 1 then
 		ss_tool.visible = false
-		awful.spawn.easy_async_with_shell('sleep 0.3 && scrot -d ' .. delay_time .. ' ~/Pictures/' .. ss_index .. '.png',
+		awful.spawn.easy_async_with_shell('sleep 0.3 && maim -d ' .. delay_time .. ' ~/Pictures/' .. ss_index .. '.png',
 			function()
 				naughty.notify
 				(
@@ -406,7 +406,7 @@ end)
 selection:connect_signal("button::release", function(_, _, _, button)
 	if button == 1 then
 		ss_tool.visible = false
-		awful.spawn.easy_async_with_shell('sleep 0.3 && scrot -s ' .. '~/Pictures/' .. ss_index .. '.png',
+		awful.spawn.easy_async_with_shell('sleep 0.3 && maim -s ' .. '~/Pictures/' .. ss_index .. '.png',
 			function()
 				naughty.notify
 				(

--- a/awesome/themes/mytheme/theme.lua
+++ b/awesome/themes/mytheme/theme.lua
@@ -1,3 +1,4 @@
+local gears = require("gears")
 local beautiful = require("beautiful")
 local dpi = beautiful.xresources.apply_dpi
 
@@ -5,6 +6,16 @@ local dpi = beautiful.xresources.apply_dpi
 local color                                           = require("layout.topbar.colors")
 
 local theme                                           = {}
+
+-- Create function to recolor the icon (taken from BlingCrop/bling)
+--  The function need to use the absolute path of the file so using ~ will not work
+local function get_icon(icon_raw)
+  if icon_raw ~= nil then
+      return gears.color.recolor_image(icon_raw, "#ffffff")
+  else
+      return nil
+  end
+end
 
 theme.font                                            = "CaskaydiaCove Nerd Font 12"
 theme.fg                                              = color.white
@@ -84,23 +95,28 @@ theme.tasklist_shape_border_color_urgent     = color.yellow
 
 
 -- Default layout icons
-theme.layout_fairh                = "/usr/share/awesome/themes/default/layouts/fairhw.png"
-theme.layout_fairv                = "/usr/share/awesome/themes/default/layouts/fairvw.png"
-theme.layout_floating             = "/usr/share/awesome/themes/default/layouts/floatingw.png"
-theme.layout_magnifier            = "/usr/share/awesome/themes/default/layouts/magnifierw.png"
-theme.layout_max                  = "/usr/share/awesome/themes/default/layouts/maxw.png"
-theme.layout_fullscreen           = "/usr/share/awesome/themes/default/layouts/fullscreenw.png"
-theme.layout_tilebottom           = "/usr/share/awesome/themes/default/layouts/tilebottomw.png"
-theme.layout_tileleft             = "/usr/share/awesome/themes/default/layouts/tileleftw.png"
-theme.layout_tile                 = "/usr/share/awesome/themes/default/layouts/tilew.png"
-theme.layout_tiletop              = "/usr/share/awesome/themes/default/layouts/tiletopw.png"
-theme.layout_spiral               = "/usr/share/awesome/themes/default/layouts/spiralw.png"
-theme.layout_dwindle              = "/usr/share/awesome/themes/default/layouts/dwindlew.png"
-theme.layout_cornernw             = "/usr/share/awesome/themes/default/layouts/cornernw.png"
-theme.layout_cornerne             = "/usr/share/awesome/themes/default/layouts/cornerne.png"
-theme.layout_cornersw             = "/usr/share/awesome/themes/default/layouts/cornersw.png"
-theme.layout_cornerse             = "/usr/share/awesome/themes/default/layouts/cornerse.png"
-
+theme.layout_fairh                = get_icon("/usr/share/awesome/themes/default/layouts/fairhw.png")
+theme.layout_fairv                = get_icon("/usr/share/awesome/themes/default/layouts/fairvw.png")
+theme.layout_floating             = get_icon("/usr/share/awesome/themes/default/layouts/floatingw.png")
+theme.layout_magnifier            = get_icon("/usr/share/awesome/themes/default/layouts/magnifierw.png")
+theme.layout_max                  = get_icon("/usr/share/awesome/themes/default/layouts/maxw.png")
+theme.layout_fullscreen           = get_icon("/usr/share/awesome/themes/default/layouts/fullscreenw.png")
+theme.layout_tilebottom           = get_icon("/usr/share/awesome/themes/default/layouts/tilebottomw.png")
+theme.layout_tileleft             = get_icon("/usr/share/awesome/themes/default/layouts/tileleftw.png")
+theme.layout_tile                 = get_icon("/usr/share/awesome/themes/default/layouts/tilew.png")
+theme.layout_tiletop              = get_icon("/usr/share/awesome/themes/default/layouts/tiletopw.png")
+theme.layout_spiral               = get_icon("/usr/share/awesome/themes/default/layouts/spiralw.png")
+theme.layout_dwindle              = get_icon("/usr/share/awesome/themes/default/layouts/dwindlew.png")
+theme.layout_cornernw             = get_icon("/usr/share/awesome/themes/default/layouts/cornernw.png")
+theme.layout_cornerne             = get_icon("/usr/share/awesome/themes/default/layouts/cornerne.png")
+theme.layout_cornersw             = get_icon("/usr/share/awesome/themes/default/layouts/cornersw.png")
+theme.layout_cornerse             = get_icon("/usr/share/awesome/themes/default/layouts/cornerse.png")
+theme.layout_centered             = get_icon(os.getenv("HOME") .. "/.config/awesome/bling/icons/layouts/centered.png")
+theme.layout_deck                 = get_icon(os.getenv("HOME") .. "/.config/awesome/bling/icons/layouts/deck.png")
+theme.layout_equalarea            = get_icon(os.getenv("HOME") .. "/.config/awesome/bling/icons/layouts/equalarea.png")
+theme.layout_horizontal           = get_icon(os.getenv("HOME") .. "/.config/awesome/bling/icons/layouts/horizontal.png")
+theme.layout_mstab                = get_icon(os.getenv("HOME") .. "/.config/awesome/bling/icons/layouts/mstab.png")
+theme.layout_vertical             = get_icon(os.getenv("HOME") .. "/.config/awesome/bling/icons/layouts/vertical.png")
 --------------------------------
 --Taglist-----------------------
 --------------------------------


### PR DESCRIPTION
The theme icons for the layouts aren't the same color, so I added a function to recolor them to `#ffffff` (function taken from `bling/layout/init.lua`). I also added the icons from bling's layouts.